### PR TITLE
HCK-4757: provide refresh interval unit explicitly

### DIFF
--- a/forward_engineering/mappers/indexSettingsMapper.js
+++ b/forward_engineering/mappers/indexSettingsMapper.js
@@ -3,6 +3,7 @@ const { getAnalyzers } = require("./analyzersMapper");
 const { getFilters } = require("./filtersMapper");
 const { isObjectEmpty } = require("./mapperHelper");
 const { getTokenizers } = require("./tokenizersMapper");
+const { getIndexRefreshInterval } = require('./refreshIntervalMapper');
 
 const getIndexSettings = (indexData, logger) => {
 	const properties = helper.getContainerLevelProperties();
@@ -17,6 +18,11 @@ const getIndexSettings = (indexData, logger) => {
 		return settings;
 	}, {});
 
+	const indexRefreshInterval = getIndexRefreshInterval({ indexData });
+	if (indexRefreshInterval) {
+		indexSettings.refresh_interval = indexRefreshInterval;
+	}
+	
 	try {
 		const analysis = getIndexAnalysisSettings(indexData);
 		if (analysis) {
@@ -41,7 +47,7 @@ const getIndexAnalysisSettings = (indexData) => {
 		...(tokenizer && { tokenizer }),
 		...(filter && { filter }),
 		...(charFilter && { char_filter: charFilter }),
-		...(normalizer && { normalizer })
+		...(normalizer && { normalizer }),
 	};
 
 	return isObjectEmpty(analysis) ? null : analysis;

--- a/forward_engineering/mappers/refreshIntervalMapper.js
+++ b/forward_engineering/mappers/refreshIntervalMapper.js
@@ -1,0 +1,13 @@
+const getIndexRefreshInterval = ({ indexData }) => {
+	if (!indexData || !indexData.refresh_interval || !indexData.refresh_interval_unit) {
+		return null;
+	}
+	if (indexData.refresh_interval < 0) {
+		return -1;
+	}
+	return [indexData.refresh_interval, indexData.refresh_interval_unit].join('');
+};
+
+module.exports = {
+	getIndexRefreshInterval
+}

--- a/forward_engineering/service/elasticsearch/elasticsearchService.js
+++ b/forward_engineering/service/elasticsearch/elasticsearchService.js
@@ -65,7 +65,7 @@ class ElasticSearchService {
      * @param jsonData {JsonData}
      */
     async _insertExampleDocument(jsonData) {
-        const { _index: indexName, _source: data, _type: typeName } = jsonData;
+        const { _index: indexName, _source: data } = jsonData;
         if (!indexName) {
             throw new Error(`Index name must be present in sample data line ${JSON.stringify(jsonData)}`);
         }
@@ -74,7 +74,6 @@ class ElasticSearchService {
         }
         await this._client.index({
             index: indexName,
-            type: typeName,
             op_type: 'index',
             body: data
         });

--- a/forward_engineering/types/elasticsearchSampleDataTypes.d.ts
+++ b/forward_engineering/types/elasticsearchSampleDataTypes.d.ts
@@ -8,7 +8,6 @@ export type EntitiesData = {
 
 export type JsonData = {
     _index: string,
-    _type?: string,
     _id: string,
     _source: Object
 }

--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -208,8 +208,25 @@ making sure that you maintain a proper JSON format.
 				"propertyValidate": false,
 				"propertyType": "numeric",
 				"valueType": "integer",
-				"allowNegative": false,
+				"allowNegative": true,
+				"minValue": -1,
 				"isTargetProperty": true
+			},
+			{
+				"propertyName": "Refresh interval unit",
+				"propertyKeyword": "refresh_interval_unit",
+				"propertyTooltip": "Measurement unit of a refresh interval property",
+				"propertyValidate": false,
+				"propertyType": "select",
+				"defaultValue": "s",
+				"options": [
+					"ms",
+					"s",
+					"m",
+					"h",
+					"d"
+				],
+				"isTargetProperty": false
 			},
 			{
 				"propertyName": "Max result window",

--- a/reverse_engineering/SchemaCreator.js
+++ b/reverse_engineering/SchemaCreator.js
@@ -286,7 +286,6 @@ module.exports = {
 	getServiceFields(sample) {
 		let schema = {
 			_index: { type: "string", mode: "text" },
-			_type: { type: "string", mode: "text" },
 			_id: { type: "string", mode: "text" },
 			_source: { type: "object", properties: {} }
 		};

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const SchemaCreator = require('./SchemaCreator');
 const inferSchemaService = require('./helpers/inferSchemaService');
 const { getAnalysisData } = require('./helpers/analysisSettingsHelper');
+const { getIndexRefreshInterval } = require('./helpers/refreshIntervalMapper');
 const versions = require('../package.json').contributes.target.versions;
 
 let connectionParams = {};
@@ -553,7 +554,8 @@ function getBucketData(mappingData, logger) {
 			'final_pipeline',
 		]);
 		const containerJSONProperties = getJSONPropertiesByKeys(settingContainer, ['blocks', 'routing']);
-		data = { ...data, ...containerProperties, ...containerJSONProperties };
+		const refreshInterval = getIndexRefreshInterval({ indexData: containerProperties });
+		data = { ...data, ...containerProperties, ...containerJSONProperties, ...refreshInterval };
 
 		if (settingContainer.analysis) {
 			try {

--- a/reverse_engineering/helpers/refreshIntervalMapper.js
+++ b/reverse_engineering/helpers/refreshIntervalMapper.js
@@ -1,0 +1,35 @@
+const getIndexRefreshInterval = ({ indexData }) => {
+	const defaultInterval = 1;
+	const defaultUnit = 's';
+
+	if (!indexData || typeof indexData.refresh_interval !== 'string') {
+		return {};
+	}
+
+	if (indexData.refresh_interval < 0) {
+		return {
+			refresh_interval: -1,
+			refresh_interval_unit: defaultUnit
+		};
+	}
+
+	const intervalRegexp = /(?<interval>-?\d+)(?<unit>\w{0,2})/;
+	const parsedInterval = indexData.refresh_interval.match(intervalRegexp);
+
+	if (!parsedInterval) {
+		return {
+			refresh_interval: defaultInterval,
+			refresh_interval_unit: defaultUnit
+		};
+	}
+
+	const { interval, unit } = parsedInterval.groups;
+	return {
+		refresh_interval: interval,
+		refresh_interval_unit: unit || defaultUnit
+	};
+};
+
+module.exports = {
+	getIndexRefreshInterval
+}


### PR DESCRIPTION
* added a new `refresh_interval_unit` selector to PP for a container

![image](https://github.com/hackolade/ElasticsearchV7plus/assets/56116665/1a109d5e-683d-4ce2-98b0-736e323360a1)

* removed [deprecated](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html) system field `_type`