### PR TITLE
HCK-15710: handle _routing mapping metadata property in RE and FE

### DIFF
--- a/forward_engineering/helpers/generateScriptHelpers.js
+++ b/forward_engineering/helpers/generateScriptHelpers.js
@@ -258,6 +258,17 @@ const getMappingScript = (indexData, typeSchema, logger, containerLevelConfig) =
 
 	mappingScript.mappings = typeSchema;
 
+	const mappingRouting = getMappingRouting(indexData);
+	if (mappingRouting) {
+		mappingScript = {
+			...mappingScript,
+			mappings: {
+				_routing: mappingRouting,
+				...mappingScript.mappings,
+			},
+		};
+	}
+
 	return mappingScript;
 };
 
@@ -330,6 +341,31 @@ const mergeSchemas = (schemaA, schemaB) => {
 	});
 
 	return result;
+};
+
+const getMappingRouting = indexData => {
+	if (!indexData.mappingRouting) {
+		return null;
+	}
+
+	const required = getBooleanValue(indexData.mappingRouting.required);
+	if (required === null) {
+		return null;
+	}
+
+	return {
+		required,
+	};
+};
+
+const getBooleanValue = value => {
+	if (value === 'true') {
+		return true;
+	}
+	if (value === 'false') {
+		return false;
+	}
+	return null;
 };
 
 module.exports = {

--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -162,6 +162,29 @@ making sure that you maintain a proper JSON format.
 		],
 		"structure": [
 			{
+				"propertyName": "Mapping metadata",
+				"propertyType": "empty"
+			},
+			{
+				"propertyName": "Routing",
+				"propertyType": "block",
+				"propertyKeyword": "mappingRouting",
+				"propertyTooltip": "Mapping routing metadata",
+				"structure": [
+					{
+						"propertyName": "Required",
+						"propertyKeyword": "required",
+						"propertyType": "select",
+						"allowEmtyValue": true,
+						"options": ["", "true", "false"]
+					}
+				]
+			},
+			{
+				"propertyName": "Index settings",
+				"propertyType": "empty"
+			},
+			{
 				"propertyName": "Number of shards",
 				"propertyKeyword": "number_of_shards",
 				"propertyTooltip": "The number of shards that an index should have.",
@@ -281,7 +304,7 @@ making sure that you maintain a proper JSON format.
 				"isTargetProperty": true
 			},
 			{
-				"propertyName": "Routing",
+				"propertyName": "Index routing",
 				"propertyKeyword": "routing",
 				"propertyType": "details",
 				"template": "textAreaJson",

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -588,7 +588,27 @@ function getBucketData(mappingData, logger, containerLevelConfig) {
 		data.aliases = aliases;
 	}
 
+	const mappingRouting = getMappingRoutingFromApi({ mappings: mappingData.mappings });
+	if (mappingRouting) {
+		data.mappingRouting = mappingRouting;
+	}
+
 	return data;
+}
+
+function getMappingRoutingFromApi({ mappings } = {}) {
+	if (!mappings || !mappings._routing) {
+		return null;
+	}
+
+	const required = mappings._routing.required;
+	if (typeof required !== 'boolean') {
+		return null;
+	}
+
+	return {
+		required: String(required),
+	};
 }
 
 function groupDocumentsByType(type, documents) {

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -597,7 +597,7 @@ function getBucketData(mappingData, logger, containerLevelConfig) {
 }
 
 function getMappingRoutingFromApi({ mappings } = {}) {
-	if (!mappings || !mappings._routing) {
+	if (!mappings?._routing) {
 		return null;
 	}
 


### PR DESCRIPTION
## Content

- Added support for the `_routing` metadata property in mapping configuration for both reverse engineering (RE) and forward engineering (FE)
- Introduced property headers in the Properties Pane to clearly separate:
  - mapping metadata properties
  - index settings properties
This avoids confusion with the existing `routing` property in index settings